### PR TITLE
Use regular queue, use flush thread per process, delay worker init

### DIFF
--- a/logtail/handler.py
+++ b/logtail/handler.py
@@ -40,21 +40,19 @@ class LogtailHandler(logging.Handler):
         self.flush_interval = flush_interval
         self.raise_exceptions = raise_exceptions
         self.dropcount = 0
-        self.flush_thread = None
-
-    def flush_thread_restart(self):
         self.flush_thread = FlushWorker(
             self.uploader,
             self.pipe,
             self.buffer_capacity,
             self.flush_interval
         )
-        self.flush_thread.start()
+        if not self.flush_thread.is_alive():
+            self.flush_thread.start()
 
     def emit(self, record):
         try:
-            if not self.flush_thread or not self.flush_thread.is_alive():
-                self.flush_thread_restart()
+            if not self.flush_thread.is_alive():
+                self.flush_thread.start()
 
             message = self.format(record)
             frame = create_frame(record, message, self.context, include_extra_attributes=self.include_extra_attributes)

--- a/logtail/handler.py
+++ b/logtail/handler.py
@@ -32,7 +32,7 @@ class LogtailHandler(logging.Handler):
         self.source_token = source_token
         self.host = host
         self.context = context
-        self.pipe = multiprocessing.JoinableQueue(maxsize=buffer_capacity)
+        self.pipe = queue.Queue(maxsize=buffer_capacity)
         self.uploader = Uploader(self.source_token, self.host)
         self.drop_extra_events = drop_extra_events
         self.include_extra_attributes = include_extra_attributes
@@ -40,22 +40,22 @@ class LogtailHandler(logging.Handler):
         self.flush_interval = flush_interval
         self.raise_exceptions = raise_exceptions
         self.dropcount = 0
+        self.flush_thread = None
+
+    def flush_thread_restart(self):
         self.flush_thread = FlushWorker(
             self.uploader,
             self.pipe,
             self.buffer_capacity,
             self.flush_interval
         )
-        if self._is_main_process():
-            self.flush_thread.start()
-
-    def _is_main_process(self):
-        return multiprocessing.current_process()._parent_pid == None
+        self.flush_thread.start()
 
     def emit(self, record):
         try:
-            if self._is_main_process() and not self.flush_thread.is_alive():
-                self.flush_thread.start()
+            if not self.flush_thread or not self.flush_thread.is_alive():
+                self.flush_thread_restart()
+
             message = self.format(record)
             frame = create_frame(record, message, self.context, include_extra_attributes=self.include_extra_attributes)
             try:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -28,10 +28,10 @@ class TestLogtailHandler(unittest2.TestCase):
             buffer_capacity=buffer_capacity,
             flush_interval=flush_interval
         )
-        self.assertEqual(handler.pipe._maxsize, buffer_capacity)
+        self.assertTrue(handler.pipe.empty())
 
     @mock.patch('logtail.handler.FlushWorker')
-    def test_handler_creates_and_starts_worker_from_args(self, MockWorker):
+    def test_handler_creates_worker_from_args(self, MockWorker):
         buffer_capacity = 9
         flush_interval = 9
         handler = LogtailHandler(source_token=self.source_token, buffer_capacity=buffer_capacity, flush_interval=flush_interval)
@@ -41,12 +41,11 @@ class TestLogtailHandler(unittest2.TestCase):
             buffer_capacity,
             flush_interval
         )
-        self.assertTrue(handler.flush_thread.start.called)
 
     @mock.patch('logtail.handler.FlushWorker')
     def test_emit_starts_thread_if_not_alive(self, MockWorker):
         handler = LogtailHandler(source_token=self.source_token)
-        self.assertTrue(handler.flush_thread.start.call_count, 1)
+        self.assertEqual(handler.flush_thread.start.call_count, 0)
         handler.flush_thread.is_alive = mock.Mock(return_value=False)
 
         logger = logging.getLogger(__name__)
@@ -54,7 +53,7 @@ class TestLogtailHandler(unittest2.TestCase):
         logger.addHandler(handler)
         logger.critical('hello')
 
-        self.assertEqual(handler.flush_thread.start.call_count, 2)
+        self.assertEqual(handler.flush_thread.start.call_count, 1)
 
     @mock.patch('logtail.handler.FlushWorker')
     def test_emit_drops_records_if_configured(self, MockWorker):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -31,22 +31,29 @@ class TestLogtailHandler(unittest2.TestCase):
         self.assertTrue(handler.pipe.empty())
 
     @mock.patch('logtail.handler.FlushWorker')
-    def test_handler_creates_worker_from_args(self, MockWorker):
+    def test_handler_creates_and_starts_worker_from_args_after_first_log(self, MockWorker):
         buffer_capacity = 9
         flush_interval = 9
         handler = LogtailHandler(source_token=self.source_token, buffer_capacity=buffer_capacity, flush_interval=flush_interval)
+
+        self.assertFalse(MockWorker.called)
+
+        logger = logging.getLogger(__name__)
+        logger.handlers = []
+        logger.addHandler(handler)
+        logger.critical('hello')
+
         MockWorker.assert_called_with(
             handler.uploader,
             handler.pipe,
             buffer_capacity,
             flush_interval
         )
+        self.assertEqual(handler.flush_thread.start.call_count, 1)
 
     @mock.patch('logtail.handler.FlushWorker')
     def test_emit_starts_thread_if_not_alive(self, MockWorker):
         handler = LogtailHandler(source_token=self.source_token)
-        self.assertEqual(handler.flush_thread.start.call_count, 0)
-        handler.flush_thread.is_alive = mock.Mock(return_value=False)
 
         logger = logging.getLogger(__name__)
         logger.handlers = []
@@ -54,6 +61,11 @@ class TestLogtailHandler(unittest2.TestCase):
         logger.critical('hello')
 
         self.assertEqual(handler.flush_thread.start.call_count, 1)
+        handler.flush_thread.is_alive = mock.Mock(return_value=False)
+
+        logger.critical('hello')
+
+        self.assertEqual(handler.flush_thread.start.call_count, 2)
 
     @mock.patch('logtail.handler.FlushWorker')
     def test_emit_drops_records_if_configured(self, MockWorker):


### PR DESCRIPTION
Use regular queue, use flush thread per process -> general changes to make this work better with serverless

Delay worker init -> Fixes issues with logtail-python on Render

