### PR TITLE
Python 3.10 and 3.11, fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,10 @@ on:
 
 jobs:
   build:
-    # As long as we need Python 2.7 here in the test, we can only use up to Ubuntu 20.
-    # https://github.com/rwth-i6/returnn/issues/1226
-    # 20.04 is a LTS with 2030 support EOL 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/logtail/flusher.py
+++ b/logtail/flusher.py
@@ -12,7 +12,7 @@ RETRY_SCHEDULE = (1, 10, 60)  # seconds
 class FlushWorker(threading.Thread):
     def __init__(self, upload, pipe, buffer_capacity, flush_interval):
         threading.Thread.__init__(self)
-        self.parent_thread = threading.currentThread()
+        self.parent_thread = threading.current_thread()
         self.upload = upload
         self.pipe = pipe
         self.buffer_capacity = buffer_capacity

--- a/logtail/frame.py
+++ b/logtail/frame.py
@@ -8,7 +8,7 @@ import __main__
 def create_frame(record, message, context, include_extra_attributes=False):
     r = record.__dict__
     # Django sends a request object in the record, which is not JSON serializable
-    if not isinstance(r["request"], (dict, list, bool, int, float, str)) :
+    if "request" in r and not isinstance(r["request"], (dict, list, bool, int, float, str)) :
         del r["request"]
     frame = {}
     # Python 3 only solution if we ever drop Python 2.7

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 coverage>=3.7.1
 httpretty>=0.9.4
-nose>=1.3.7
-unittest2>=0.8.0
+nose-py3
 mock>=1.0.1

--- a/tests/test_flusher.py
+++ b/tests/test_flusher.py
@@ -3,7 +3,7 @@ from __future__ import print_function, unicode_literals
 import mock
 import time
 import threading
-import unittest2
+import unittest
 
 from logtail.compat import queue
 from logtail.flusher import RETRY_SCHEDULE
@@ -11,7 +11,7 @@ from logtail.flusher import FlushWorker
 from logtail.uploader import Uploader
 
 
-class TestFlushWorker(unittest2.TestCase):
+class TestFlushWorker(unittest.TestCase):
     host = 'https://in.logtail.com'
     source_token = 'dummy_source_token'
     buffer_capacity = 5

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -4,7 +4,7 @@ import mock
 import time
 import threading
 import json
-import unittest2
+import unittest
 import pdb
 import logging
 
@@ -13,7 +13,7 @@ from logtail.formatter import LogtailFormatter
 from logtail.helpers import LogtailContext
 
 
-class TestLogtailFormatter(unittest2.TestCase):
+class TestLogtailFormatter(unittest.TestCase):
     def setUp(self):
         self.context = LogtailContext()
         self.customer = {'id': '1'}

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -5,10 +5,10 @@ from logtail.handler import LogtailHandler
 from logtail.helpers import LogtailContext
 from sys import version_info
 import datetime
-import unittest2
+import unittest
 import logging
 
-class TestLogtailLogEntry(unittest2.TestCase):
+class TestLogtailLogEntry(unittest.TestCase):
     def test_create_frame_happy_path(self):
         handler = LogtailHandler(source_token="some-source-token")
         log_record = logging.LogRecord("logtail-test", 20, "/some/path", 10, "Some log message", [], None)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -3,13 +3,13 @@ from __future__ import print_function, unicode_literals
 import mock
 import time
 import threading
-import unittest2
+import unittest
 import logging
 
 from logtail.handler import LogtailHandler
 
 
-class TestLogtailHandler(unittest2.TestCase):
+class TestLogtailHandler(unittest.TestCase):
     source_token = 'dummy_source_token'
     host = 'dummy_host'
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 from __future__ import print_function, unicode_literals
-import unittest2
+import unittest
 
 from logtail import LogtailContext
 
 
-class TestLogtailContext(unittest2.TestCase):
+class TestLogtailContext(unittest.TestCase):
 
     def test_exists(self):
         c = LogtailContext()

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2,12 +2,12 @@
 from __future__ import print_function, unicode_literals
 import msgpack
 import mock
-import unittest2
+import unittest
 
 from logtail.uploader import Uploader
 
 
-class TestUploader(unittest2.TestCase):
+class TestUploader(unittest.TestCase):
     host = 'https://in.logtail.com'
     source_token = 'dummy_source_token'
     frame = [1, 2, 3]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, py310, py311
+envlist = py27, py37, py38, py39, py310, py311
 
 [gh-actions]
 python =
     2.7: py27
-    3.5: py35
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py27, py37, py38, py39, py310, py311
+envlist = py37, py38, py39, py310, py311
 
 [gh-actions]
 python =
-    2.7: py27
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39
+envlist = py27, py35, py36, py37, py38, py39, py310, py311
 
 [gh-actions]
 python =
@@ -9,6 +9,8 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
`DeprecationWarning: currentThread() is deprecated, use current_thread() instead`

python 3.11.2