### PR TITLE
Allow custom log levels

### DIFF
--- a/logtail/frame.py
+++ b/logtail/frame.py
@@ -62,14 +62,7 @@ def _parse_custom_events(record, include_extra_attributes):
 
 
 def _levelname(level):
-    return {
-        'debug': 'debug',
-        'info': 'info',
-        'warning': 'warn',
-        'error': 'error',
-        'critical': 'critical',
-    }[level.lower()]
-
+    return level.lower()
 
 def _relative_to_main_module_if_possible(pathname):
     has_main_module = hasattr(__main__, '__file__')


### PR DESCRIPTION
The current "_levelname" function does not allow custom levels, I think it will be great to allow custom log levels.
I did not add any validation to the function since I didn't know what limitation you have on your side.
