### PR TITLE
L-110 Continue flushing after shutdown until pipe is empty

### DIFF
--- a/logtail/__init__.py
+++ b/logtail/__init__.py
@@ -5,6 +5,6 @@ from .handler import LogtailHandler
 from .helpers import LogtailContext, DEFAULT_CONTEXT
 from .formatter import LogtailFormatter
 
-__version__ = '0.2.6'
+__version__ = '0.2.7'
 
 context = DEFAULT_CONTEXT

--- a/logtail/flusher.py
+++ b/logtail/flusher.py
@@ -67,7 +67,7 @@ class FlushWorker(threading.Thread):
             if response.status_code == 500 and getattr(response, "exception") != None:
                 print('Failed to send logs to Better Stack after {} retries: {}'.format(len(RETRY_SCHEDULE), response.exception))
 
-        if shutdown:
+        if shutdown and self.pipe.empty():
             sys.exit(0)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 
-VERSION = '0.2.6'
+VERSION = '0.2.7'
 ROOT_DIR = os.path.dirname(__file__)
 
 REQUIREMENTS = [


### PR DESCRIPTION
Some logs may have been left unsent on process termination. Wait with exiting the process until pipe is empty.

---

Tested with this block in `example-project` script right below `logger` initialization:

```py
import threading
import time

def some_thread_function():
    print("Starting thread")
    time.sleep(1)
    for i in range(10):
        logger.debug("I am using Logtail in a thread! " + str(i))
    print("Ending thread")

t = threading.Thread(target=some_thread_function, daemon=True)
t.start()
```

Before suggested changes, `I am using Logtail in a thread! 0` was the last message send (instead of `I am using Logtail in a thread! 9`)