### PR TITLE
LogtailHandler: implement logging.Handler.flush

### DIFF
--- a/logtail/handler.py
+++ b/logtail/handler.py
@@ -12,6 +12,7 @@ from .frame import create_frame
 DEFAULT_HOST = 'https://in.logs.betterstack.com'
 DEFAULT_BUFFER_CAPACITY = 1000
 DEFAULT_FLUSH_INTERVAL = 1
+DEFAULT_CHECK_INTERVAL = 0.1
 DEFAULT_RAISE_EXCEPTIONS = False
 DEFAULT_DROP_EXTRA_EVENTS = True
 DEFAULT_INCLUDE_EXTRA_ATTRIBUTES = True
@@ -23,6 +24,7 @@ class LogtailHandler(logging.Handler):
                  host=DEFAULT_HOST,
                  buffer_capacity=DEFAULT_BUFFER_CAPACITY,
                  flush_interval=DEFAULT_FLUSH_INTERVAL,
+                 check_interval=DEFAULT_CHECK_INTERVAL,
                  raise_exceptions=DEFAULT_RAISE_EXCEPTIONS,
                  drop_extra_events=DEFAULT_DROP_EXTRA_EVENTS,
                  include_extra_attributes=DEFAULT_INCLUDE_EXTRA_ATTRIBUTES,
@@ -38,6 +40,7 @@ class LogtailHandler(logging.Handler):
         self.include_extra_attributes = include_extra_attributes
         self.buffer_capacity = buffer_capacity
         self.flush_interval = flush_interval
+        self.check_interval = check_interval
         self.raise_exceptions = raise_exceptions
         self.dropcount = 0
         # Do not initialize the flush thread yet because it causes issues on Render.
@@ -51,7 +54,8 @@ class LogtailHandler(logging.Handler):
             self.uploader,
             self.pipe,
             self.buffer_capacity,
-            self.flush_interval
+            self.flush_interval,
+            self.check_interval,
         )
         self.flush_thread.start()
 
@@ -71,3 +75,7 @@ class LogtailHandler(logging.Handler):
         except Exception as e:
             if self.raise_exceptions:
                 raise e
+
+    def flush(self):
+        if self.flush_thread and self.flush_thread.is_alive():
+             self.flush_thread.flush()

--- a/tests/test_flusher.py
+++ b/tests/test_flusher.py
@@ -17,11 +17,12 @@ class TestFlushWorker(unittest.TestCase):
     source_token = 'dummy_source_token'
     buffer_capacity = 5
     flush_interval = 2
+    check_interval = 0.01
 
     def _setup_worker(self, uploader=None):
         pipe = queue.Queue(maxsize=self.buffer_capacity)
         uploader = uploader or Uploader(self.source_token, self.host)
-        fw = FlushWorker(uploader, pipe, self.buffer_capacity, self.flush_interval)
+        fw = FlushWorker(uploader, pipe, self.buffer_capacity, self.flush_interval, self.check_interval)
         return pipe, uploader, fw
 
     def test_is_thread(self):

--- a/tests/test_flusher.py
+++ b/tests/test_flusher.py
@@ -6,6 +6,8 @@ import time
 import threading
 import unittest
 
+from unittest.mock import patch
+
 from logtail.compat import queue
 from logtail.flusher import RETRY_SCHEDULE
 from logtail.flusher import FlushWorker
@@ -51,7 +53,7 @@ class TestFlushWorker(unittest.TestCase):
 
         self.assertEqual(self.calls, 1)
 
-    @mock.patch('logtail.flusher._calculate_time_remaining')
+    @patch('logtail.flusher._calculate_time_remaining')
     def test_flushes_after_interval(self, calculate_time_remaining):
         self.buffer_capacity = 10
         num_items = 2
@@ -83,8 +85,8 @@ class TestFlushWorker(unittest.TestCase):
         self.assertEqual(self.upload_calls, 1)
         self.assertEqual(self.timeout_calls, 2)
 
-    @mock.patch('logtail.flusher._calculate_time_remaining')
-    @mock.patch('logtail.flusher._initial_time_remaining')
+    @patch('logtail.flusher._calculate_time_remaining')
+    @patch('logtail.flusher._initial_time_remaining')
     def test_does_nothing_without_any_items(self, initial_time_remaining, calculate_time_remaining):
         calculate_time_remaining.side_effect = lambda a,b: 0.0
         initial_time_remaining.side_effect = lambda a: 0.0001
@@ -96,7 +98,7 @@ class TestFlushWorker(unittest.TestCase):
         fw.step()
         self.assertFalse(uploader.called)
 
-    @mock.patch('logtail.flusher.time.sleep')
+    @patch('logtail.flusher.time.sleep')
     def test_retries_according_to_schedule(self, mock_sleep):
         first_frame = list(range(self.buffer_capacity))
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -6,20 +6,22 @@ import threading
 import unittest
 import logging
 
-from logtail import LogtailHandler, context
+from unittest.mock import patch
 
+from logtail import LogtailHandler, context
+from logtail.handler import FlushWorker
 
 class TestLogtailHandler(unittest.TestCase):
     source_token = 'dummy_source_token'
     host = 'dummy_host'
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_handler_creates_uploader_from_args(self, MockWorker):
         handler = LogtailHandler(source_token=self.source_token, host=self.host)
         self.assertEqual(handler.uploader.source_token, self.source_token)
         self.assertEqual(handler.uploader.host, self.host)
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_handler_creates_pipe_from_args(self, MockWorker):
         buffer_capacity = 9
         flush_interval = 1
@@ -30,7 +32,7 @@ class TestLogtailHandler(unittest.TestCase):
         )
         self.assertTrue(handler.pipe.empty())
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_handler_creates_and_starts_worker_from_args_after_first_log(self, MockWorker):
         buffer_capacity = 9
         flush_interval = 9
@@ -53,7 +55,7 @@ class TestLogtailHandler(unittest.TestCase):
         )
         self.assertEqual(handler.flush_thread.start.call_count, 1)
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_emit_starts_thread_if_not_alive(self, MockWorker):
         handler = LogtailHandler(source_token=self.source_token)
 
@@ -69,7 +71,7 @@ class TestLogtailHandler(unittest.TestCase):
 
         self.assertEqual(handler.flush_thread.start.call_count, 2)
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_emit_drops_records_if_configured(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(
@@ -89,7 +91,7 @@ class TestLogtailHandler(unittest.TestCase):
         self.assertTrue(handler.pipe.empty())
         self.assertEqual(handler.dropcount, 1)
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_emit_does_not_drop_records_if_configured(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(
@@ -120,7 +122,7 @@ class TestLogtailHandler(unittest.TestCase):
 
         self.assertEqual(handler.dropcount, 0)
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_error_suppression(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(
@@ -141,7 +143,7 @@ class TestLogtailHandler(unittest.TestCase):
         handler.raise_exceptions = False
         logger.critical('hello')
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_can_send_unserializable_extra_data(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(
@@ -160,7 +162,7 @@ class TestLogtailHandler(unittest.TestCase):
         self.assertRegex(log_entry['data']['unserializable'], r'^<tests\.test_handler\.UnserializableObject object at 0x[0-f]+>$')
         self.assertTrue(handler.pipe.empty())
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_can_send_unserializable_context(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(
@@ -180,7 +182,7 @@ class TestLogtailHandler(unittest.TestCase):
         self.assertRegex(log_entry['context']['data']['unserializable'], r'^<tests\.test_handler\.UnserializableObject object at 0x[0-f]+>$')
         self.assertTrue(handler.pipe.empty())
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_can_send_circular_dependency_in_extra_data(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(
@@ -202,7 +204,7 @@ class TestLogtailHandler(unittest.TestCase):
         self.assertTrue(handler.pipe.empty())
 
 
-    @mock.patch('logtail.handler.FlushWorker')
+    @patch('logtail.handler.FlushWorker')
     def test_can_send_circular_dependency_in_context(self, MockWorker):
         buffer_capacity = 1
         handler = LogtailHandler(

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -34,7 +34,8 @@ class TestLogtailHandler(unittest.TestCase):
     def test_handler_creates_and_starts_worker_from_args_after_first_log(self, MockWorker):
         buffer_capacity = 9
         flush_interval = 9
-        handler = LogtailHandler(source_token=self.source_token, buffer_capacity=buffer_capacity, flush_interval=flush_interval)
+        check_interval = 4
+        handler = LogtailHandler(source_token=self.source_token, buffer_capacity=buffer_capacity, flush_interval=flush_interval, check_interval=check_interval)
 
         self.assertFalse(MockWorker.called)
 
@@ -47,7 +48,8 @@ class TestLogtailHandler(unittest.TestCase):
             handler.uploader,
             handler.pipe,
             buffer_capacity,
-            flush_interval
+            flush_interval,
+            check_interval,
         )
         self.assertEqual(handler.flush_thread.start.call_count, 1)
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -4,6 +4,8 @@ import msgpack
 import mock
 import unittest
 
+from unittest.mock import patch
+
 from logtail.uploader import Uploader
 
 
@@ -12,7 +14,7 @@ class TestUploader(unittest.TestCase):
     source_token = 'dummy_source_token'
     frame = [1, 2, 3]
 
-    @mock.patch('logtail.uploader.requests.Session.post')
+    @patch('logtail.uploader.requests.Session.post')
     def test_call(self, post):
         def mock_post(endpoint, data=None, headers=None):
             # Check that the data is sent to ther correct endpoint


### PR DESCRIPTION
Implementing `flush` method on our handler. 

The method should be implemented by subclasses of `logging.Handler`. It's called automatically during graceful termination.
https://github.com/python/cpython/blob/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/logging/__init__.py#L1039-L1046

The method will enforce uploading the current buffer to Better Stack sooner than in `flush_interval`, and will wait until all data are sent to Better Stack.

---

Making `check_interval` configurable and decreasing the default value from 1s to 100ms, as it may have serious impact on short-running code (example project took ~1.3s to finish before this PR, now takes ~350ms).

---

It is now safe to terminate execution immediately (eg. using `os._exit`), if `flush()` is called before:

```
for handler in logger.handlers:
    handler.flush()

os._exit(os.EX_OK)
```