### PR TITLE
Improve omitting circular references

### DIFF
--- a/logtail/frame.py
+++ b/logtail/frame.py
@@ -62,13 +62,14 @@ def _remove_circular_dependencies(obj, memo=None):
         memo = set()
     if id(obj) in memo:
         return "<omitted circular reference>"
-    memo.add(id(obj))
     if isinstance(obj, dict):
+        memo.add(id(obj))
         new_dict = {}
         for key, value in obj.items():
             new_dict[key] = _remove_circular_dependencies(value, memo)
         return new_dict
     elif isinstance(obj, list):
+        memo.add(id(obj))
         new_list = [_remove_circular_dependencies(item, memo) for item in obj]
         return new_list
     else:

--- a/logtail/frame.py
+++ b/logtail/frame.py
@@ -60,18 +60,23 @@ def _parse_custom_events(record, include_extra_attributes):
 def _remove_circular_dependencies(obj, memo=None):
     if memo is None:
         memo = set()
+    # Skip immutable types, which can't contain circular dependencies
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
     if id(obj) in memo:
         return "<omitted circular reference>"
+    memo.add(id(obj))
     if isinstance(obj, dict):
-        memo.add(id(obj))
         new_dict = {}
         for key, value in obj.items():
             new_dict[key] = _remove_circular_dependencies(value, memo)
         return new_dict
     elif isinstance(obj, list):
-        memo.add(id(obj))
-        new_list = [_remove_circular_dependencies(item, memo) for item in obj]
-        return new_list
+        return [_remove_circular_dependencies(item, memo) for item in obj]
+    elif isinstance(obj, tuple):
+        return tuple(_remove_circular_dependencies(item, memo) for item in obj)
+    elif isinstance(obj, set):
+        return {_remove_circular_dependencies(item, memo) for item in obj}
     else:
         return obj
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -203,6 +203,26 @@ class TestLogtailHandler(unittest.TestCase):
         self.assertEqual(log_entry['data']['egg']['chicken'], "<omitted circular reference>")
         self.assertTrue(handler.pipe.empty())
 
+    @patch('logtail.handler.FlushWorker')
+    def test_can_have_multiple_instance_of_same_string_in_extra_data(self, MockWorker):
+        buffer_capacity = 1
+        handler = LogtailHandler(
+            source_token=self.source_token,
+            buffer_capacity=buffer_capacity
+        )
+
+        logger = logging.getLogger(__name__)
+        logger.handlers = []
+        logger.addHandler(handler)
+        test_string = 'this is a test string'
+        logger.info('hello', extra={'test1': test_string, 'test2': test_string})
+
+        log_entry = handler.pipe.get()
+
+        self.assertEqual(log_entry['message'], 'hello')
+        self.assertEqual(log_entry['test1'], 'this is a test string')
+        self.assertEqual(log_entry['test2'], 'this is a test string')
+        self.assertTrue(handler.pipe.empty())
 
     @patch('logtail.handler.FlushWorker')
     def test_can_send_circular_dependency_in_context(self, MockWorker):


### PR DESCRIPTION
Avoids replacing scalars by `"<omitted circular reference>"`, as it doesn't make sense - bools, string, ints and floats cannot contain circular references.

Also omits circular references in tuples and sets.