### PR TITLE
LogtailHandler: Do not expect "host" parameter to include protocol

### DIFF
--- a/logtail/handler.py
+++ b/logtail/handler.py
@@ -9,7 +9,7 @@ from .flusher import FlushWorker
 from .uploader import Uploader
 from .frame import create_frame
 
-DEFAULT_HOST = 'https://in.logs.betterstack.com'
+DEFAULT_HOST = 'in.logs.betterstack.com'
 DEFAULT_BUFFER_CAPACITY = 1000
 DEFAULT_FLUSH_INTERVAL = 1
 DEFAULT_CHECK_INTERVAL = 0.1
@@ -32,7 +32,10 @@ class LogtailHandler(logging.Handler):
                  level=logging.NOTSET):
         super(LogtailHandler, self).__init__(level=level)
         self.source_token = source_token
-        self.host = host
+        if host.startswith('https://') or host.startswith('http://'):
+            self.host = host
+        else:
+            self.host = "https://" + host
         self.context = context
         self.pipe = queue.Queue(maxsize=buffer_capacity)
         self.uploader = Uploader(self.source_token, self.host)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 
-VERSION = '0.3.2'
+VERSION = '0.3.3'
 ROOT_DIR = os.path.dirname(__file__)
 
 REQUIREMENTS = [


### PR DESCRIPTION
Previously, `host` needed to include the `https://` which is unintuitive:

```python
from logtail import LogtailHandler
import logging

handler = LogtailHandler(
    source_token='$SOURCE_TOKEN', 
    host='https://in.logs.betterstack.com',
)
logger = logging.getLogger(__name__)
logger.setLevel(logging.INFO)
logger.handlers = []
logger.addHandler(handler)

```

Now, we should also support just ingesting host being sent, as noted in #31:

```python
from logtail import LogtailHandler
import logging

handler = LogtailHandler(
    source_token='$SOURCE_TOKEN', 
    host='in.logs.betterstack.com',
)
logger = logging.getLogger(__name__)
logger.setLevel(logging.INFO)
logger.handlers = []
logger.addHandler(handler)
```