### PR TITLE
SH-1002 [CI] Update GitHub Actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.x']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions (forced to Node 24 since June 2nd, 2026; Node 20 removed from runners on September 16th, 2026), and Node 12/16 actions are already force-migrated. This bumps the affected actions to their latest majors (all Node 24):

- `actions/checkout` `v1` → `v7`
- `actions/setup-python` `v2` → `v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
